### PR TITLE
Fixed missing argument error

### DIFF
--- a/photogrammetry_importer/mesh_import_properties.py
+++ b/photogrammetry_importer/mesh_import_properties.py
@@ -16,7 +16,7 @@ class MeshImportProperties():
         mesh_box = layout.box()
         mesh_box.prop(self, "import_mesh")
                     
-    def import_photogrammetry_mesh(self, mesh_fp, reconstruction_collection, op):
+    def import_photogrammetry_mesh(self, mesh_fp, reconstruction_collection):
         if self.import_mesh and mesh_fp is not None:
             self.report({'INFO'}, 'Importing mesh: ...')
             previous_collection = bpy.context.collection

--- a/photogrammetry_importer/photogrammetry_import_op.py
+++ b/photogrammetry_importer/photogrammetry_import_op.py
@@ -89,7 +89,7 @@ class ImportColmap(CameraImportProperties, PointImportProperties, MeshImportProp
         reconstruction_collection = add_collection('Reconstruction Collection')
         self.import_photogrammetry_cameras(cameras, reconstruction_collection)
         self.import_photogrammetry_points(points, reconstruction_collection)
-        self.import_photogrammetry_mesh(mesh_ifp, reconstruction_collection, self)
+        self.import_photogrammetry_mesh(mesh_ifp, reconstruction_collection)
 
         self.report({'INFO'}, 'Parse Colmap model folder: Done')
 


### PR DESCRIPTION
Upon importing a meshroom scene I was hitting an error caused by calling `import_photogrammetry_mesh` without an `op` argument. It appears that argument is no longer used within the function, so I've removed it and fixed the one remaining use in a calling function.

I haven't been able to test `self.import_photogrammetry_mesh(mesh_ifp`, but the change looks pretty safe to me.