### PR TITLE
Handle alpha channel and set spherical camera focal length to 1

### DIFF
--- a/photogrammetry_importer/file_handlers/openmvg_json_file_handler.py
+++ b/photogrammetry_importer/file_handlers/openmvg_json_file_handler.py
@@ -103,7 +103,7 @@ class OpenMVGJSONFileHandler:
                         Camera.panoramic_type_equirectangular
                     )
                     # create some dummy values
-                    focal_length = 0
+                    focal_length = 1
                     cx = camera.width / 2
                     cy = camera.height / 2
                 else:
@@ -231,9 +231,8 @@ class OpenMVGJSONFileHandler:
                     )  # y has index 1
 
                     current_image = view_index_to_image[view_index]
-                    current_r, current_g, current_b = current_image.getpixel(
-                        (x_json_file, y_json_file)
-                    )
+                    pix = current_image.getpixel((x_json_file, y_json_file))
+                    current_r, current_g, current_b = pix[0], pix[1], pix[2]
                     r += current_r
                     g += current_g
                     b += current_b


### PR DESCRIPTION
Hey,

I made a small set of changes to handle spherical cameras from openMVG SfM files.

First, focal length needs to be set to `1` else the assert [here](https://github.com/SBCV/Blender-Addon-Photogrammetry-Importer/blob/e17237e33ba70d32a095e4f5690b97bf6efb1682/photogrammetry_importer/types/camera.py#L191) triggers.

Also, `getpixel()` method from Pillow can return 3 or 4 values depending if images are RGB or RGBA respectively. By default, the code only handles RGB so I added a correction to account for both.

Cheers