### PR TITLE
Add colored sphere to each vertex in 'add points as mesh' mode

### DIFF
--- a/photogrammetry_importer/importers/point_utility.py
+++ b/photogrammetry_importer/importers/point_utility.py
@@ -79,8 +79,7 @@ def _create_particle_color_nodes(
         divide_node = node_tree.nodes.new("ShaderNodeMath")
         divide_node.operation = "DIVIDE"
         node_tree.links.new(
-            shift_half_pixel_node.outputs["Value"],
-            divide_node.inputs[0],
+            shift_half_pixel_node.outputs["Value"], divide_node.inputs[0]
         )
         divide_node.inputs[1].default_value = texture_size
 
@@ -290,8 +289,11 @@ def add_points_as_mesh_vertices(
         point_cloud_mesh, point_cloud_obj_name, reconstruction_collection
     )
     if add_mesh_to_point_geometry_nodes:
-        # Only visible if cycles is activated
-        bpy.context.scene.render.engine = "CYCLES"
+        # Add a point_color attribute to each vertex
+        point_cloud_mesh.attributes.new(
+            name="point_color", type="FLOAT_COLOR", domain="POINT"
+        )
+        add_colors_to_vertices(point_cloud_mesh, colors, "point_color")
 
         geometry_nodes = point_cloud_obj.modifiers.new(
             "GeometryNodes", "NODES"
@@ -300,16 +302,72 @@ def add_points_as_mesh_vertices(
         group_input = geometry_nodes.node_group.nodes["Group Input"]
         group_output = geometry_nodes.node_group.nodes["Group Output"]
 
+        # Add modifier inputs that are editable from the GUI, the order these are added is important
+        geometry_nodes.node_group.inputs.new(
+            "NodeSocketMaterial", "Point Color"
+        )  # Input_2
+        geometry_nodes.node_group.inputs.new(
+            "NodeSocketFloat", "Point Radius"
+        )  # Input_3
+        geometry_nodes.node_group.inputs.new(
+            "NodeSocketIntUnsigned", "Point Subdivisions"
+        )  # Input_4
+        geometry_nodes["Input_2"] = get_color_from_attribute("point_color")
+        geometry_nodes["Input_3"] = 0.02
+        geometry_nodes["Input_4"] = 1
+
         # Note: To determine the name required for new(...), create the
         # corresponding node with the gui and print the value of "bl_rna".
+        # Or enable python tooltips under preferences > interface and hover
+        # over a node in the add node dropdown
         mesh_to_points = geometry_nodes.node_group.nodes.new(
             "GeometryNodeMeshToPoints"
         )
+        instance_on_points = geometry_nodes.node_group.nodes.new(
+            "GeometryNodeInstanceOnPoints"
+        )
+        realize_instances = geometry_nodes.node_group.nodes.new(
+            "GeometryNodeRealizeInstances"
+        )
+        sphere_marker = geometry_nodes.node_group.nodes.new(
+            "GeometryNodeMeshIcoSphere"
+        )
+        set_material = geometry_nodes.node_group.nodes.new(
+            "GeometryNodeSetMaterial"
+        )
+
         geometry_nodes.node_group.links.new(
             group_input.outputs["Geometry"], mesh_to_points.inputs["Mesh"]
         )
         geometry_nodes.node_group.links.new(
-            mesh_to_points.outputs["Points"], group_output.inputs["Geometry"]
+            mesh_to_points.outputs["Points"],
+            instance_on_points.inputs["Points"],
+        )
+        geometry_nodes.node_group.links.new(
+            instance_on_points.outputs["Instances"],
+            realize_instances.inputs["Geometry"],
+        )
+        geometry_nodes.node_group.links.new(
+            realize_instances.outputs["Geometry"],
+            group_output.inputs["Geometry"],
+        )
+
+        geometry_nodes.node_group.links.new(
+            group_input.outputs["Point Radius"], sphere_marker.inputs["Radius"]
+        )
+        geometry_nodes.node_group.links.new(
+            group_input.outputs["Point Subdivisions"],
+            sphere_marker.inputs["Subdivisions"],
+        )
+        geometry_nodes.node_group.links.new(
+            sphere_marker.outputs["Mesh"], set_material.inputs["Geometry"]
+        )
+        geometry_nodes.node_group.links.new(
+            group_input.outputs["Point Color"], set_material.inputs["Material"]
+        )
+        geometry_nodes.node_group.links.new(
+            set_material.outputs["Geometry"],
+            instance_on_points.inputs["Instance"],
         )
 
     if add_color_as_custom_property:
@@ -318,3 +376,30 @@ def add_points_as_mesh_vertices(
     log_report("INFO", "Duration: " + str(stop_watch.get_elapsed_time()), op)
     log_report("INFO", "Adding Points as Mesh: Done", op)
     return point_cloud_obj
+
+
+def add_colors_to_vertices(mesh, colors, attribute_name):
+    """Add a color attribute to each vertex of mesh."""
+    if len(mesh.vertices) != len(colors):
+        raise ValueError(
+            f"Got {len(mesh.vertices)} vertices and {len(colors)} color values."
+        )
+
+    color_array = np.array(colors)
+    color_array[:, :3] /= 255.0
+    mesh.attributes[attribute_name].data.foreach_set(
+        "color", color_array.reshape(-1)
+    )
+
+
+def get_color_from_attribute(attribute_name):
+    """Create a material that obtains its color from the specified attribute."""
+    material = bpy.data.materials.new("color")
+    material.use_nodes = True
+    color_node = material.node_tree.nodes.new("ShaderNodeAttribute")
+    color_node.attribute_name = attribute_name
+    material.node_tree.links.new(
+        color_node.outputs["Color"],
+        material.node_tree.nodes["Principled BSDF"].inputs["Base Color"],
+    )
+    return material


### PR DESCRIPTION
Instances an IcoSphere object on each vertex when 'add points as mesh' is selected in the import options. The radius and polygon-count of the spheres can be edited in the modifiers tab when the pointcloud is selected. 

Should solve this issue: https://github.com/SBCV/Blender-Addon-Photogrammetry-Importer/issues/45

Rendered view:
![colmap_render](https://user-images.githubusercontent.com/12471058/174816734-c122fbf2-4cae-4730-834d-bfabcf4f5ee4.png)


Here are the node trees it generates:
![Screenshot from 2022-06-21 15-43-54](https://user-images.githubusercontent.com/12471058/174814746-cd3f245e-e3f3-4e53-af27-29f61234c24c.png)

and here's a video showing it works: https://www.youtube.com/watch?v=NDT5zhhfQvo

I've only tried it on colmap with blender 3.1.2 but since I'm working with the loaded points/colors I assume other formats should be OK? The only thing that's required is that `np.array(colors)` results in a `n_vertices x 4` array
