### PR TITLE
Camera sorting routine should sort numerically not alphabetically

### DIFF
--- a/photogrammetry_importer/importers/camera_animation_utility.py
+++ b/photogrammetry_importer/importers/camera_animation_utility.py
@@ -370,7 +370,7 @@ def add_camera_animation(
     )
 
     cameras_sorted = sorted(
-        cameras, key=lambda camera: camera.get_relative_fp()
+        cameras, key=lambda camera: int(''.join(filter(str.isdigit, camera.get_relative_fp())))
     )
 
     transformations_sorted = []


### PR DESCRIPTION
Alphabetically, "10.png" is sorted before "2.png", which causes the frame order to be wrong in the animated camera. This fixes it.