### PR TITLE
Transform on 3D point cloud export

### DIFF
--- a/photogrammetry_importer/operators/export_op.py
+++ b/photogrammetry_importer/operators/export_op.py
@@ -1,4 +1,5 @@
 import bpy
+import mathutils
 from photogrammetry_importer.types.point import Point
 from photogrammetry_importer.importers.camera_utility import (
     get_computer_vision_camera,
@@ -54,7 +55,7 @@ class ExportOperator(bpy.types.Operator):
                     coords = obj["particle_coords"]
                     colors = obj["particle_colors"]
                     for coord, color in zip(coords, colors):
-                        coord_world = coord
+                        coord_world = obj.matrix_world @ mathutils.Vector(coord)
                         scaled_color = [round(value * 255) for value in color]
                         obj_points.append(
                             Point(


### PR DESCRIPTION
When trying to export back to COLMAP, I noticed the camera got transformed properly but not the 3D points.

I believe they should get transformed as well, since I move the cameras and the point cloud together (which causes issues when exporting to colmap since the point cloud transform is not transferred).

I added this little change that seem to work properly on my side.
Maybe there is a way to specify this only for COLMAP export, if it causes issues for other type of exports.