### PR TITLE
Deduplication of image filename on COLMAP export

### DIFF
--- a/photogrammetry_importer/file_handlers/colmap_file_handler.py
+++ b/photogrammetry_importer/file_handlers/colmap_file_handler.py
@@ -1,4 +1,5 @@
 import os
+import re
 import numpy as np
 
 from photogrammetry_importer.ext.read_dense import read_array
@@ -355,13 +356,17 @@ class ColmapFileHandler:
                 params=np.array([cam.get_focal_length(), pp[0], pp[1]]),
             )
             colmap_cams[cam.id] = colmap_cam
-
+            
+            image_filename = cam.get_file_name()
+            if (re.findall(r"\.\d\d\d$", image_filename)):
+                image_filename = image_filename[:-4]
+                
             colmap_image = ColmapImage(
                 id=cam.id,
                 qvec=cam.get_rotation_as_quaternion(),
                 tvec=cam.get_translation_vec(),
                 camera_id=cam.id,
-                name=cam.get_file_name(),
+                name=image_filename,
                 xys=[],
                 point3D_ids=[],
             )


### PR DESCRIPTION
Blender automatically add a .ddd suffix to objects with the same name to avoid name clashing.

Since different colmap models can use common images, these suffixes get added automatically.
This is a problem on export since `my_image_cam` could exist but `my_image_cam.001` doesn't.

When trying to load back the model into colmap or some other software (nerfstudio in my case), the image is not found and the process end in an error. This is particularly painful on many shared images when dealing with multiple models at once.

This change automatically trims the Blender suffix . Since the suffix `_cam` is already added to image filenames, I think it would always work.