### PR TITLE
feat(camera): Improve camera intrinsic handling / added Colmap PINHOLE camera export

### DIFF
--- a/photogrammetry_importer/operators/colmap_export_op.py
+++ b/photogrammetry_importer/operators/colmap_export_op.py
@@ -1,6 +1,6 @@
 import os
 import bpy
-from bpy.props import StringProperty, CollectionProperty
+from bpy.props import StringProperty, CollectionProperty, EnumProperty
 from bpy_extras.io_utils import ExportHelper
 
 from photogrammetry_importer.file_handlers.colmap_file_handler import (
@@ -25,6 +25,16 @@ class ExportColmapOperator(ExportOperator, ExportHelper):
         type=bpy.types.OperatorFileListElement,
     )
 
+    camera_model: EnumProperty(
+        name="Camera Model",
+        description="Choose the camera model for export",
+        items=[
+            ("SIMPLE_PINHOLE", "Simple Pinhole", "Single focal length (f, cx, cy)"),
+            ("PINHOLE", "Pinhole", "Separate focal lengths (fx, fy, cx, cy)"),
+        ],
+        default="SIMPLE_PINHOLE",
+    )
+
     filename_ext = ""
     # filter_folder : BoolProperty(default=True, options={'HIDDEN'})
 
@@ -37,6 +47,6 @@ class ExportColmapOperator(ExportOperator, ExportHelper):
         for cam in cameras:
             assert cam.get_calibration_mat() is not None
 
-        ColmapFileHandler.write_colmap_model(odp, cameras, points, self)
+        ColmapFileHandler.write_colmap_model(odp, cameras, points, camera_model=self.camera_model, op=self)
 
         return {"FINISHED"}

--- a/photogrammetry_importer/types/camera.py
+++ b/photogrammetry_importer/types/camera.py
@@ -232,11 +232,18 @@ class Camera:
         return self._panoramic_type
 
     @staticmethod
+    def compute_calibration_mat_with_focal_lengths(fx, fy, cx, cy, skew=0.0):
+        """Return the calibration matrix with separate fx and fy."""
+        return np.array(
+            [[fx, skew, cx], [0, fy, cy], [0, 0, 1]],
+            dtype=float,
+        )
+
+    @staticmethod
     def compute_calibration_mat(focal_length, cx, cy):
         """Return the calibration matrix."""
-        return np.array(
-            [[focal_length, 0, cx], [0, focal_length, cy], [0, 0, 1]],
-            dtype=float,
+        return Camera.compute_calibration_mat_with_focal_lengths(
+            fx=focal_length, fy=focal_length, cx=cx, cy=cy
         )
 
     def set_rotation_with_quaternion(self, quaternion):


### PR DESCRIPTION
This commit enhances the addon's core camera conversion utilities to correctly handle non-square pixels by preserving distinct horizontal (fx) and vertical (fy) focal lengths.

This was primarily driven by the need to add a "PINHOLE" camera model option to the Colmap exporter, but the underlying changes benefit the entire addon. The import-export round-trip for camera intrinsics is now lossless.

This enhancement improves the accuracy and robustness of all camera-based importers and exporters in the addon, ensuring better interoperability between different photogrammetry formats (e.g., Colmap, Meshroom, OpenMVG) and other Blender tools.

An application of this feature is the ability to export camera data for use with [3D Gaussian Splatting](https://github.com/graphdeco-inria/gaussian-splatting), which requires a Colmap folder with the PINHOLE camera model.

Example usage in code: 
```python
bpy.ops.export_scene.colmap(
    directory=output_dir,
    files=[{"name": output_dir_name}],
    camera_model="PINHOLE" # defaults to "SIMPLE_PINHOLE"
)
```